### PR TITLE
Fixing python env hint

### DIFF
--- a/.config/fish/config.fish
+++ b/.config/fish/config.fish
@@ -11,14 +11,14 @@ set SCHEME_GREY 666666          # Darkish grey
 set fish_color_search_match $SCHEME_GREY
 set fish_greeting ""
 
+# Setup pyenv & pyenv-virtualenv
+status --is-interactive; and source (pyenv init -|psub)
+status --is-interactive; and source (pyenv virtualenv-init -|psub)
+
 # Setup /usr/local/bin before /usr/bin.
 set -g fish_user_paths "/usr/local/bin" $fish_user_paths;
 # Fix for `gettext` not found for pyenv.
 set -g fish_user_paths "/usr/local/opt/gettext/bin" $fish_user_paths;
-
-# Setup pyenv & pyenv-virtualenv
-status --is-interactive; and source (pyenv init -|psub)
-status --is-interactive; and source (pyenv virtualenv-init -|psub)
 
 # The next line updates PATH for the Google Cloud SDK.
 if [ -f "$HOME/google-cloud-sdk/path.fish.inc" ];

--- a/.config/fish/functions/_env_hints.fish
+++ b/.config/fish/functions/_env_hints.fish
@@ -21,7 +21,7 @@ function _env_hints --description "Prompt hits for git, pyenv etc."
     # Are we in a virtualenv?
     if set --query VIRTUAL_ENV
         # Get the version via pyenv.
-        set --global --export PYENV_VERSION (expr (pyenv version) : '\([^ ]*\)')
+        set --global --export PYENV_VERSION (pyenv version-name)
         # Determine the python version in the pyenv
         set --local py_version (python --version)
 

--- a/.config/fish/functions/_env_hints.fish
+++ b/.config/fish/functions/_env_hints.fish
@@ -14,7 +14,10 @@ function _env_hints --description "Prompt hits for git, pyenv etc."
 
         __print_color $SCHEME_INFO "$lambda $br_name "
         __print_color $SCHEME_GREY "($git_status)"
-        __print_color $SCHEME_GREY " $bullet "
+        # Only print bullet if there is virtualenv
+        if set --query VIRTUAL_ENV
+            __print_color $SCHEME_GREY " $bullet "
+        end
     end
 
     #
@@ -27,7 +30,6 @@ function _env_hints --description "Prompt hits for git, pyenv etc."
 
         __print_color $SCHEME_INFO "$snake  $PYENV_VERSION "
         __print_color $SCHEME_GREY "($py_version)"
-        __print_color $SCHEME_GREY " $bullet "
     end
 
     # Add a newline after the env hints

--- a/.config/fish/functions/_env_hints.fish
+++ b/.config/fish/functions/_env_hints.fish
@@ -23,7 +23,7 @@ function _env_hints --description "Prompt hits for git, pyenv etc."
         # Get the version via pyenv.
         set --global --export PYENV_VERSION (pyenv version-name)
         # Determine the python version in the pyenv
-        set --local py_version (python --version)
+        set --local py_version (python --version ^&1)
 
         __print_color $SCHEME_INFO "$snake  $PYENV_VERSION "
         __print_color $SCHEME_GREY "($py_version)"


### PR DESCRIPTION
- Use `pyenv version-name` so we don't have to use a regexp.
- Capture stderr/stdout for `python --version` so that miniconda versions also work.